### PR TITLE
Fix: Instr from current chord instead of last note

### DIFF
--- a/data/midi-to-encoding.py
+++ b/data/midi-to-encoding.py
@@ -47,7 +47,7 @@ def stream_to_chordwise(s, chamber, note_range, note_offset, sample_freq):
     for c in s.recurse().addFilter(chordFilter):
         pitchesInChord=c.pitches
         if chamber:
-            instrumentID=assign_instrument(n.activeSite.getInstrument())     
+            instrumentID=assign_instrument(c.activeSite.getInstrument())     
             if instrumentID==-1:
                 return []
 


### PR DESCRIPTION
Instrument ID was being incorrectly pulled from the last note from the previous loop (using last value of `n`). This caused (in my case), all chord data to be assigned to the piano instrument. Updated code to use the current value of `c` as each chord is iterated.